### PR TITLE
Default Version poller

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -32,7 +32,7 @@ func TestAppRewrite(t *testing.T) {
 }
 
 func TestVersionSwitch(t *testing.T) {
-	versionSwitch := VersionSwitch("default")
+	versionSwitch := VersionSwitch(func() string { return "default" })
 
 	for _, tc := range []struct {
 		name         string

--- a/main_test.go
+++ b/main_test.go
@@ -32,7 +32,7 @@ func TestAppRewrite(t *testing.T) {
 }
 
 func TestVersionSwitch(t *testing.T) {
-	versionSwitch := VersionSwitch(func() string { return "default" })
+	versionSwitch := VersionSwitch(normalStringReader("default"))
 
 	for _, tc := range []struct {
 		name         string


### PR DESCRIPTION
Loads the default version from the remote source, polling every minute for updates.

This avoids the need to re-deploy on every change, but the env var functionality is retained if that's desired.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dutyofcare/spa-version-proxy/3)
<!-- Reviewable:end -->
